### PR TITLE
Adding a checker for selected element in order to avoid re-creating observer on a selected element

### DIFF
--- a/src/useEditable.ts
+++ b/src/useEditable.ts
@@ -256,21 +256,28 @@ export const useEditable = (
   if (typeof navigator !== 'object') return edit;
 
   useLayoutEffect(() => {
-    state.onChange = onChange;
+    // We need to block the re-attachment of observer in case of re-render on a SELECTED element
+    // Otherwise, we will get a new observer for the same element and it will cause unconsistent caret state.
+    if (elementRef.current !== document.activeElement) {
+      state.onChange = onChange;
 
-    if (!elementRef.current || opts!.disabled) return;
+      if (!elementRef.current || opts!.disabled) return;
 
-    state.disconnected = false;
-    state.observer.observe(elementRef.current, observerSettings);
-    if (state.position) {
-      const { position, extent } = state.position;
-      setCurrentRange(
-        makeRange(elementRef.current, position, position + extent)
-      );
+      state.disconnected = false;
+      state.observer.observe(elementRef.current, observerSettings);
+      if (state.position) {
+        const { position, extent } = state.position;
+        setCurrentRange(
+          makeRange(elementRef.current, position, position + extent)
+        );
+      }
     }
 
     return () => {
-      state.observer.disconnect();
+      if (elementRef.current === document.activeElement) {
+        console.log('disconnect');
+        state.observer.disconnect();
+      }
     };
   });
 


### PR DESCRIPTION
**What does this PR do?**
**What are the relevant tickets?**
In a currently active issue reported here: https://github.com/FormidableLabs/use-editable/issues/14 I spotted a problem when having an element selected being re-rendered.
**Any background context you can provide?**
The problem seem to be caused because having the effect disconnecting and re-connecting the observer which causes a lost of the caret state and even sometimes the selector.

The fix is to avoid doing this reconnection if the element is already selected as IMHO as far as I understand this disconnection is not needed. 

I would appreciate feedback on why do we disconnect and reconnect on each re-render as isn't clear to me.