### PR TITLE
fix: issue 26 – add timeout to execute in next cycle

### DIFF
--- a/src/useEditable.ts
+++ b/src/useEditable.ts
@@ -454,7 +454,7 @@ export const useEditable = (
       if (!isUndoRedoKey(event)) trackState();
       flushChanges();
       // Chrome Quirk: The contenteditable may lose focus after the first edit or so
-      element.focus();
+      setTimeout(() => element.focus(), 0);
     };
 
     const onSelect = (event: Event) => {


### PR DESCRIPTION
This PR addresses https://github.com/FormidableLabs/use-editable/issues/26

By forcing the `element.focus()` action to execute in the next event cycle it now properly works with the Chrome quirk. This should not be a breaking change.
